### PR TITLE
move @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "homepage": "https://github.com/rricard/graphql-document-collector#readme",
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/glob": "^5.0.30",
+    "@types/node": "^6.0.41",
+    "@types/mocha": "^2.2.32",
     "mocha": "^3.1.0",
     "typescript": "^2.0.3"
   },
   "dependencies": {
-    "@types/chai": "^3.4.34",
-    "@types/glob": "^5.0.30",
-    "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.41",
     "chai": "^3.5.0",
     "glob": "^7.1.0",
     "graphql-tag": "^0.1.14",


### PR DESCRIPTION
Remove dependency for @types in prod. These are only needed during ts compilation and cause typing conflicts when installed per project, when using conflicting typings. IE: Other test suites conflict with Mocha