### PR TITLE
Support gql tagged template literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/glob": "^5.0.30",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",
+    "babylon": "^6.16.1",
     "chai": "^3.5.0",
     "glob": "^7.1.0",
     "graphql-tag": "^0.1.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,6 @@ export default function loadTransformAndFlatten(
   return loadGlob(basePath, globPath)
   .then(root =>
     flattenDirectoryStructure(applyTransforms(root, ...transforms))
-  );
+  )
+  .catch(err => console.log(err.stack));
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,3 +12,5 @@ declare module 'graphql-tag/parser' {
 declare module 'graphql-tag/printer' {
   function print(ast: any): string;
 }
+
+declare module 'babylon';


### PR DESCRIPTION
This is a rough sketch for what this feature should look like. Some questions:

- Should the parser be specifiable? (i.e. babylon, acorn, etc.)
  - also, could we avoid using a parser altogether?
- Should options to the parser be specifiable? (i.e. flow, jsx extensions)
- Should the tagged template literal be specifiable? (i.e. `gql` vs `Relay.QL`)
- Should this be usable via the CLI interface? Currently this keys off of the `.graphql` file extension.

Related to https://github.com/apollographql/apollo-codegen/issues/25

```tsx
const query = gql`query {

}`
```