### PR TITLE
Move test deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   "homepage": "https://github.com/rricard/graphql-document-collector#readme",
   "devDependencies": {
     "mocha": "^3.1.0",
-    "typescript": "^2.0.3"
+    "chai": "^3.5.0",
+    "typescript": "^2.0.3",
+    "@types/chai": "^3.4.34",
+    "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "@types/chai": "^3.4.34",
     "@types/glob": "^5.0.30",
-    "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.41",
-    "chai": "^3.5.0",
     "glob": "^7.1.0",
     "graphql-tag": "^0.1.14",
     "typed-graphql": "^1.0.2"


### PR DESCRIPTION
Moves the dependencies of tests to devDependencies. Having @types/mocha installed was screwing things up in my Angular install