### PR TITLE
Resolve only fragments not defined in the query

### DIFF
--- a/src/transforms/__tests__/resolveFragments.ts
+++ b/src/transforms/__tests__/resolveFragments.ts
@@ -57,5 +57,16 @@ describe('Resolve fragments transformer', () => {
         assert.equal(transformedRoot.directories[1].documents[0].definitions.length, 3);
       });
     });
+
+    it('should not re-add fragments already defined in the document', () => {
+      return loadGlob(
+        path.join(__dirname, '..', '..', '..', 'example'),
+        '**/*.graphql'
+      )
+      .then((root: DocumentDirectory) => {
+        const transformedRoot = resolveFragments(resolveFragments(root));
+        assert.equal(transformedRoot.directories[1].documents[0].definitions.length, 3);
+      });
+    });
   });
 });

--- a/src/transforms/resolveFragments.ts
+++ b/src/transforms/resolveFragments.ts
@@ -44,8 +44,13 @@ function fragmentSpreadsInSelectionSet(
 
 export function addFragmentsToDocument(document: DocumentNode, fMap: FragmentMap): DocumentNode {
   // TODO: make this function pure
+  let definedFragments: Array<string> = [];
   let fragmentSpreads: Set<string> = new Set()
   document.definitions.forEach(def => {
+    if (def.kind === 'FragmentDefinition') {
+      definedFragments.push((def as FragmentDefinitionNode).name.value);
+    }
+
     if (def.kind === 'OperationDefinition' || def.kind === 'FragmentDefinition') {
       const selSetDef = (def as OperationDefinitionNode|FragmentDefinitionNode);
       fragmentSpreadsInSelectionSet(selSetDef.selectionSet, fMap, fragmentSpreads)
@@ -54,7 +59,7 @@ export function addFragmentsToDocument(document: DocumentNode, fMap: FragmentMap
   return Object.assign({}, document, {
     definitions: [
       ...document.definitions,
-      ...Array.from(fragmentSpreads).map(sp => fMap[sp]),
+      ...Array.from(fragmentSpreads).filter(sp => definedFragments.indexOf(sp) === -1).map(sp => fMap[sp]),
     ],
   });
 }


### PR DESCRIPTION
The collector was appending fragment definitions to query documents that already defined the fragment, resulting in multiple definitions of the same fragment in the query.

This change ensures that the resolver only appends fragment definitions to queries when the fragment is not already defined in the query document.