### PR TITLE
Fix fragmentSpreadsInSelectionSet to handle inline fragments

### DIFF
--- a/inlineFragmentExample/documents.json
+++ b/inlineFragmentExample/documents.json
@@ -1,0 +1,460 @@
+{
+  "fragments/onFilm/Movie.graphql": {
+    "kind": "Document",
+    "definitions": [
+      {
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "Movie",
+          "loc": { "start": 9, "end": 14 }
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Film",
+            "loc": { "start": 18, "end": 22 }
+          },
+          "loc": { "start": 18, "end": 22 }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "id",
+                "loc": { "start": 27, "end": 29 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 27, "end": 29 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "title",
+                "loc": { "start": 32, "end": 37 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 32, "end": 37 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "director",
+                "loc": { "start": 40, "end": 48 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 40, "end": 48 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "planetConnection",
+                "loc": { "start": 51, "end": 67 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "alias": null,
+                    "name": {
+                      "kind": "Name",
+                      "value": "planets",
+                      "loc": { "start": 74, "end": 81 }
+                    },
+                    "arguments": [],
+                    "directives": [],
+                    "selectionSet": {
+                      "kind": "SelectionSet",
+                      "selections": [
+                        {
+                          "kind": "FragmentSpread",
+                          "name": {
+                            "kind": "Name",
+                            "value": "Place",
+                            "loc": { "start": 93, "end": 98 }
+                          },
+                          "directives": [],
+                          "loc": { "start": 90, "end": 98 }
+                        }
+                      ],
+                      "loc": { "start": 82, "end": 104 }
+                    },
+                    "loc": { "start": 74, "end": 104 }
+                  }
+                ],
+                "loc": { "start": 68, "end": 108 }
+              },
+              "loc": { "start": 51, "end": 108 }
+            }
+          ],
+          "loc": { "start": 23, "end": 110 }
+        },
+        "loc": { "start": 0, "end": 110 }
+      },
+      {
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "Place",
+          "loc": { "start": 9, "end": 14 }
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Planet",
+            "loc": { "start": 18, "end": 24 }
+          },
+          "loc": { "start": 18, "end": 24 }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "name",
+                "loc": { "start": 29, "end": 33 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 29, "end": 33 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "climates",
+                "loc": { "start": 36, "end": 44 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 36, "end": 44 }
+            }
+          ],
+          "loc": { "start": 25, "end": 46 }
+        },
+        "loc": { "start": 0, "end": 46 }
+      }
+    ],
+    "loc": { "start": 0, "end": 111 },
+    "name": { "kind": "Name", "value": "Movie.graphql" }
+  },
+  "fragments/onPlanet/Place.graphql": {
+    "kind": "Document",
+    "definitions": [
+      {
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "Place",
+          "loc": { "start": 9, "end": 14 }
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Planet",
+            "loc": { "start": 18, "end": 24 }
+          },
+          "loc": { "start": 18, "end": 24 }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "name",
+                "loc": { "start": 29, "end": 33 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 29, "end": 33 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "climates",
+                "loc": { "start": 36, "end": 44 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 36, "end": 44 }
+            }
+          ],
+          "loc": { "start": 25, "end": 46 }
+        },
+        "loc": { "start": 0, "end": 46 }
+      }
+    ],
+    "loc": { "start": 0, "end": 47 },
+    "name": { "kind": "Name", "value": "Place.graphql" }
+  },
+  "queries/ListMovies.graphql": {
+    "kind": "Document",
+    "definitions": [
+      {
+        "kind": "OperationDefinition",
+        "operation": "query",
+        "name": {
+          "kind": "Name",
+          "value": "ListMovies",
+          "loc": { "start": 6, "end": 16 }
+        },
+        "variableDefinitions": [],
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "allFilms",
+                "loc": { "start": 21, "end": 29 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "alias": null,
+                    "name": {
+                      "kind": "Name",
+                      "value": "films",
+                      "loc": { "start": 36, "end": 41 }
+                    },
+                    "arguments": [],
+                    "directives": [],
+                    "selectionSet": {
+                      "kind": "SelectionSet",
+                      "selections": [
+                        {
+                          "kind": "FragmentSpread",
+                          "name": {
+                            "kind": "Name",
+                            "value": "Movie",
+                            "loc": { "start": 53, "end": 58 }
+                          },
+                          "directives": [],
+                          "loc": { "start": 50, "end": 58 }
+                        }
+                      ],
+                      "loc": { "start": 42, "end": 64 }
+                    },
+                    "loc": { "start": 36, "end": 64 }
+                  }
+                ],
+                "loc": { "start": 30, "end": 68 }
+              },
+              "loc": { "start": 21, "end": 68 }
+            }
+          ],
+          "loc": { "start": 17, "end": 70 }
+        },
+        "loc": { "start": 0, "end": 70 }
+      },
+      {
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "Movie",
+          "loc": { "start": 9, "end": 14 }
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Film",
+            "loc": { "start": 18, "end": 22 }
+          },
+          "loc": { "start": 18, "end": 22 }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "id",
+                "loc": { "start": 27, "end": 29 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 27, "end": 29 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "title",
+                "loc": { "start": 32, "end": 37 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 32, "end": 37 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "director",
+                "loc": { "start": 40, "end": 48 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 40, "end": 48 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "planetConnection",
+                "loc": { "start": 51, "end": 67 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": {
+                "kind": "SelectionSet",
+                "selections": [
+                  {
+                    "kind": "Field",
+                    "alias": null,
+                    "name": {
+                      "kind": "Name",
+                      "value": "planets",
+                      "loc": { "start": 74, "end": 81 }
+                    },
+                    "arguments": [],
+                    "directives": [],
+                    "selectionSet": {
+                      "kind": "SelectionSet",
+                      "selections": [
+                        {
+                          "kind": "FragmentSpread",
+                          "name": {
+                            "kind": "Name",
+                            "value": "Place",
+                            "loc": { "start": 93, "end": 98 }
+                          },
+                          "directives": [],
+                          "loc": { "start": 90, "end": 98 }
+                        }
+                      ],
+                      "loc": { "start": 82, "end": 104 }
+                    },
+                    "loc": { "start": 74, "end": 104 }
+                  }
+                ],
+                "loc": { "start": 68, "end": 108 }
+              },
+              "loc": { "start": 51, "end": 108 }
+            }
+          ],
+          "loc": { "start": 23, "end": 110 }
+        },
+        "loc": { "start": 0, "end": 110 }
+      },
+      {
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "Place",
+          "loc": { "start": 9, "end": 14 }
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Planet",
+            "loc": { "start": 18, "end": 24 }
+          },
+          "loc": { "start": 18, "end": 24 }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "name",
+                "loc": { "start": 29, "end": 33 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 29, "end": 33 }
+            },
+            {
+              "kind": "Field",
+              "alias": null,
+              "name": {
+                "kind": "Name",
+                "value": "climates",
+                "loc": { "start": 36, "end": 44 }
+              },
+              "arguments": [],
+              "directives": [],
+              "selectionSet": null,
+              "loc": { "start": 36, "end": 44 }
+            }
+          ],
+          "loc": { "start": 25, "end": 46 }
+        },
+        "loc": { "start": 0, "end": 46 }
+      }
+    ],
+    "loc": { "start": 0, "end": 71 },
+    "name": { "kind": "Name", "value": "ListMovies.graphql" }
+  }
+}

--- a/inlineFragmentExample/fragments/onFilm/Movie.graphql
+++ b/inlineFragmentExample/fragments/onFilm/Movie.graphql
@@ -1,0 +1,10 @@
+fragment Movie on Film {
+  id
+  title
+  director
+  planetConnection {
+    planets {
+      ...Place
+    }
+  }
+}

--- a/inlineFragmentExample/fragments/onPlanet/Place.graphql
+++ b/inlineFragmentExample/fragments/onPlanet/Place.graphql
@@ -1,0 +1,4 @@
+fragment Place on Planet {
+  name
+  climates
+}

--- a/inlineFragmentExample/queries/ListMovies.graphql
+++ b/inlineFragmentExample/queries/ListMovies.graphql
@@ -1,0 +1,9 @@
+query ListMovies {
+  allFilms {
+    films {
+      ...on Thing {
+        ...Movie
+      }
+    }
+  }
+}

--- a/src/transforms/__tests__/resolveFragments.ts
+++ b/src/transforms/__tests__/resolveFragments.ts
@@ -44,6 +44,19 @@ describe('Resolve fragments transformer', () => {
         assert.equal(transformedDoc.definitions.length, 3);
       });
     });
+    
+    it('should resolve all inline fragments', () => {
+      return loadGlob(
+        path.join(__dirname, '..', '..', '..', 'inlineFragmentExample'),
+        '**/*.graphql'
+      )
+      .then((root: DocumentDirectory) => {
+        const fMap = createFragmentMap(root);
+        const origDoc = root.directories[1].documents[0];
+        const transformedDoc = addFragmentsToDocument(origDoc, fMap);
+        assert.equal(transformedDoc.definitions.length, 3);
+      });
+    });
   });
 
   describe('resolveFragments', () => {

--- a/src/transforms/resolveFragments.ts
+++ b/src/transforms/resolveFragments.ts
@@ -5,6 +5,7 @@ import {
   SelectionSetNode,
   FragmentSpreadNode,
   FieldNode,
+  InlineFragmentNode,
 } from 'graphql';
 import {DocumentDirectory} from '../ast';
 
@@ -37,6 +38,8 @@ function fragmentSpreadsInSelectionSet(
       fragmentSpreadsInSelectionSet(fMap[fragmentName].selectionSet, fMap, fragmentSpreads);
     } else if (sel.kind === 'Field' && (sel as FieldNode).selectionSet) {
       fragmentSpreadsInSelectionSet((sel as FieldNode).selectionSet, fMap, fragmentSpreads);
+    } else if ((sel.kind === 'InlineFragment')) {
+      fragmentSpreadsInSelectionSet((sel as InlineFragmentNode).selectionSet, fMap, fragmentSpreads);
     }
   });
   return fragmentSpreads;
@@ -56,6 +59,7 @@ export function addFragmentsToDocument(document: DocumentNode, fMap: FragmentMap
       fragmentSpreadsInSelectionSet(selSetDef.selectionSet, fMap, fragmentSpreads)
     }
   });
+
   return Object.assign({}, document, {
     definitions: [
       ...document.definitions,


### PR DESCRIPTION
Fix a problem with recognising inline fragments.

See [https://github.com/apollographql/graphql-document-collector/issues/17](https://github.com/apollographql/graphql-document-collector/issues/17) for details.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [x] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->